### PR TITLE
Fix false positives in common password substring matching

### DIFF
--- a/proton-pass-common/src/password/scorer.rs
+++ b/proton-pass-common/src/password/scorer.rs
@@ -196,9 +196,14 @@ fn penalties_password(password: &str) -> Vec<PasswordPenalty> {
 fn password_without_common(password: &str) -> (String, bool) {
     let password_as_lowercase = password.to_lowercase();
     for common_password in COMMON_PASSWORDS {
+        // Skip short common passwords that cover less than half the input
+        if common_password.len() * 2 < password.len() {
+            continue;
+        }
+
         if password_as_lowercase.contains(common_password) {
-            // Create a case-insensitive regex pattern
-            let pattern = match Regex::new(&format!("(?i){common_password}")) {
+            // Escape regex metacharacters (passwords.txt has entries like "123456789.")
+            let pattern = match Regex::new(&format!("(?i){}", regex_lite::escape(common_password))) {
                 Ok(r) => r,
                 Err(_) => continue,
             };

--- a/proton-pass-common/tests/password_scorer.rs
+++ b/proton-pass-common/tests/password_scorer.rs
@@ -86,3 +86,21 @@ penalties_test! {
     upper_only: ("SECUREWORD", vec![PasswordPenalty::NoNumbers, PasswordPenalty::NoLowercase, PasswordPenalty::NoSymbols, PasswordPenalty::Short]),
     symbol_no_upper_num: ("P@ssw0rd!", vec![PasswordPenalty::ContainsCommonPassword, PasswordPenalty::Short, PasswordPenalty::Consecutive]),
 }
+
+// Regression: adding a character to a password must never lower its score.
+// Before the fix, "AsDFoundry07=+*" contained "asdf" (4 chars) as a substring,
+// which got stripped to "oundry07=+*" (11 chars), scoring much lower than
+// "ADFoundry07=+*" (no "asdf" substring). Short common passwords should not
+// match as substrings inside longer unrelated passwords.
+#[test]
+fn appending_a_char_must_not_lower_score() {
+    let base = check_score("ADFoundry07=+*");
+    let extended = check_score("AsDFoundry07=+*");
+    assert!(
+        extended.numeric_score >= base.numeric_score,
+        "'AsDFoundry07=+*' (score={}) should be >= 'ADFoundry07=+*' (score={})",
+        extended.numeric_score,
+        base.numeric_score,
+    );
+}
+


### PR DESCRIPTION
This PR fixes two issues in common-password matching that could lead to incorrect password scores.

First, some entries in passwords.txt contain regex metacharacters such as 123456789. and 123456789*. These values were inserted directly into a regex:

`Regex::new(&format!("(?i){common_password}"))`

As a result, those characters were treated as regex syntax instead of literal text. For example, 123456789. would match 123456789x, so a password like Hello123456789xWorld could be incorrectly detected as containing the common password 123456789. This PR fixes that by escaping common password entries with regex_lite::escape() before building the regex.

Second, very short common passwords such as asdf could match as substrings inside unrelated longer passwords. When that happened, the matched substring was removed before rescoring, which could unfairly lower the final score. For example, ADFoundry07=+* scores as Strong, while AsDFoundry07=+* scores as Weak. The only difference is the extra s, which creates the substring asdf. That substring was then stripped, shortening the password enough to reduce its score. A longer password should never score lower just because it happens to contain a short common substring.

This PR fixes that by ignoring common-password matches unless the match covers at least half of the input length. That still allows asdf to match passwords like asdf and asdf1, while preventing false positives inside longer passwords such as AsDFoundry07=+*.

Test coverage

Added the regression test `appending_a_char_must_not_lower_score`.